### PR TITLE
CSW-908: Remove references to osteology to retire Portal

### DIFF
--- a/pahma/solrETL-internal.sh
+++ b/pahma/solrETL-internal.sh
@@ -16,9 +16,8 @@
 ##############################################################################
 date
 ##############################################################################
-# note that there are 4 nightly scripts, public, internal, and locations,
-# and osteology.
-# the scripts need to run in order: public > internal > locations | osteology.
+# note that there are 3 nightly scripts, public, internal, and locations,
+# the scripts need to run in order: public > internal > locations.
 # internal (this script) depends on data created by public
 # while most of this script is already tenant specific, many of the specific commands
 # are shared between the different scripts; having them be as similar as possible

--- a/pahma/solrETL-public.sh
+++ b/pahma/solrETL-public.sh
@@ -7,8 +7,8 @@
 ##############################################################################
 date
 ##############################################################################
-# note that in this case there are 4 nightly scripts, public, internal, and locations,
-# and osteology. internal depends on data created by public, so this case has to be handled
+# note that in this case there are 3 nightly scripts, public, internal, and locations.
+# internal depends on data created by public, so this case has to be handled
 # specially, and the scripts need to run in order: public > internal > locations
 ##############################################################################
 # while most of this script is already tenant specific, many of the specific commands

--- a/solr-cores/addfield2solr.sh
+++ b/solr-cores/addfield2solr.sh
@@ -23,7 +23,6 @@ cinefiles-public
 pahma-public
 pahma-internal
 pahma-locations
-pahma-osteology
 ucjeps-public
 ucjeps-media
 "

--- a/solr-cores/legacy/make_cores.sh
+++ b/solr-cores/legacy/make_cores.sh
@@ -26,7 +26,7 @@ TOOLS="$1/datasources/ucb/multicore"
 
 for t in bampfa botgarden ucjeps pahma cinefiles
 do
-  for type in public internal media propagations osteology locations
+  for type in public internal media propagations locations
     do
       if [ -f ${TOOLS}/${t}.${type}.managed-schema ]
       then

--- a/solr-cores/legacy/make_schema.sh
+++ b/solr-cores/legacy/make_schema.sh
@@ -50,7 +50,7 @@ done
 
 for t in pahma
 do
-  for type in osteology locations
+  for type in locations
     do
       makeaschema
     done

--- a/solr-cores/legacy/solr.xml
+++ b/solr-cores/legacy/solr.xml
@@ -37,7 +37,6 @@
     <core name="pahma-media" instanceDir="pahma/media" />
 
     <core name="pahma-locations" instanceDir="pahma/locations" />
-    <core name="pahma-osteology" instanceDir="pahma/osteology" />
 
     <core name="ucjeps-public" instanceDir="ucjeps/public" />
     <core name="ucjeps-internal" instanceDir="ucjeps/internal" />

--- a/solr-cores/makesolrcores.sh
+++ b/solr-cores/makesolrcores.sh
@@ -23,7 +23,6 @@ cinefiles-public
 pahma-public
 pahma-internal
 pahma-locations
-pahma-osteology
 ucjeps-public
 ucjeps-media
 ucjeps-merritt

--- a/utilities/checkcores.sh
+++ b/utilities/checkcores.sh
@@ -2,7 +2,7 @@
 
 for t in bampfa botgarden cinefiles pahma ucjeps
 do
-    for d in public internal propagations locations media osteology
+    for d in public internal propagations locations media
     do
        # echo `curl -s -S "http://localhost:8983/solr/${t}-${d}/admin/ping"`
        if [[ `curl -s -S "http://localhost:8983/solr/${t}-${d}/admin/ping" | grep 'status'` =~ .*"OK".* ]]

--- a/utilities/checkstatus.sh
+++ b/utilities/checkstatus.sh
@@ -8,7 +8,7 @@ source ${HOME}/pipeline-config.sh -q
 
 for t in bampfa botgarden cinefiles pahma ucjeps
 do
-    for d in public internal propagations locations media osteology
+    for d in public internal propagations locations media
     do
        LOG=${SOLR_LOG_DIR}/${t}.solr_extract_${d}.log
        if [[ -e ${LOG} ]]

--- a/utilities/curl4solr.sh
+++ b/utilities/curl4solr.sh
@@ -15,7 +15,6 @@ curl -O https://webapps.cspace.berkeley.edu/4solr.cinefiles.public.csv.gz
 curl -O https://webapps.cspace.berkeley.edu/4solr.cinefiles.films.csv.gz
 curl -O https://webapps.cspace.berkeley.edu/4solr.pahma.locations.csv.gz
 curl -O https://webapps.cspace.berkeley.edu/4solr.pahma.allmedia.csv.gz
-curl -O https://webapps.cspace.berkeley.edu/4solr.pahma.osteology.csv.gz
 curl -O https://webapps.cspace.berkeley.edu/4solr.pahma.public.csv.gz
 curl -O https://webapps.cspace.berkeley.edu/4solr.ucjeps.media.csv.gz
 curl -O https://webapps.cspace.berkeley.edu/4solr.ucjeps.public.csv.gz

--- a/utilities/make_curls.sh
+++ b/utilities/make_curls.sh
@@ -8,7 +8,7 @@
 rm -f allcurls.sh
 for TENANT in bampfa botgarden cinefiles pahma ucjeps
 do
-    for CORE in public internal propagations locations media osteology
+    for CORE in public internal propagations locations media
     do
        FILE_PART=${CORE}
        if [[ -e ${HOME}/solrdatasources/${TENANT}/uploadparms.${TENANT}.${FILE_PART}.txt ]]

--- a/utilities/oj.pahma.sh
+++ b/utilities/oj.pahma.sh
@@ -5,4 +5,3 @@ source ${HOME}/pipeline-config.sh
 ${HOME}/solrdatasources/pahma/solrETL-public.sh            pahma     2>&1 | /usr/bin/ts '[%Y-%m-%d %H:%M:%S]' >> ${SOLR_LOG_DIR}/pahma.solr_extract_public.log  2>&1
 ${HOME}/solrdatasources/pahma/solrETL-internal.sh          pahma     2>&1 | /usr/bin/ts '[%Y-%m-%d %H:%M:%S]' >> ${SOLR_LOG_DIR}/pahma.solr_extract_internal.log  2>&1
 ${HOME}/solrdatasources/pahma/solrETL-locations.sh         pahma     2>&1 | /usr/bin/ts '[%Y-%m-%d %H:%M:%S]' >> ${SOLR_LOG_DIR}/pahma.solr_extract_locations.log  2>&1
-# ${HOME}/solrdatasources/pahma/solrETL-osteology.sh         pahma     2>&1 | /usr/bin/ts '[%Y-%m-%d %H:%M:%S]' >> ${SOLR_LOG_DIR}/pahma.solr_extract_osteology.log  2>&1

--- a/utilities/oj.pahma.sh
+++ b/utilities/oj.pahma.sh
@@ -5,4 +5,4 @@ source ${HOME}/pipeline-config.sh
 ${HOME}/solrdatasources/pahma/solrETL-public.sh            pahma     2>&1 | /usr/bin/ts '[%Y-%m-%d %H:%M:%S]' >> ${SOLR_LOG_DIR}/pahma.solr_extract_public.log  2>&1
 ${HOME}/solrdatasources/pahma/solrETL-internal.sh          pahma     2>&1 | /usr/bin/ts '[%Y-%m-%d %H:%M:%S]' >> ${SOLR_LOG_DIR}/pahma.solr_extract_internal.log  2>&1
 ${HOME}/solrdatasources/pahma/solrETL-locations.sh         pahma     2>&1 | /usr/bin/ts '[%Y-%m-%d %H:%M:%S]' >> ${SOLR_LOG_DIR}/pahma.solr_extract_locations.log  2>&1
-${HOME}/solrdatasources/pahma/solrETL-osteology.sh         pahma     2>&1 | /usr/bin/ts '[%Y-%m-%d %H:%M:%S]' >> ${SOLR_LOG_DIR}/pahma.solr_extract_osteology.log  2>&1
+# ${HOME}/solrdatasources/pahma/solrETL-osteology.sh         pahma     2>&1 | /usr/bin/ts '[%Y-%m-%d %H:%M:%S]' >> ${SOLR_LOG_DIR}/pahma.solr_extract_osteology.log  2>&1

--- a/utilities/optimize.sh
+++ b/utilities/optimize.sh
@@ -6,7 +6,6 @@ time curl -S -s http://localhost:8983/solr/botgarden-public/update --data '<opti
 time curl -S -s http://localhost:8983/solr/cinefiles-public/update --data '<optimize/>' -H 'Content-type:text/xml; charset=utf-8'
 time curl -S -s http://localhost:8983/solr/pahma-internal/update --data '<optimize/>' -H 'Content-type:text/xml; charset=utf-8'
 time curl -S -s http://localhost:8983/solr/pahma-locations/update --data '<optimize/>' -H 'Content-type:text/xml; charset=utf-8'
-time curl -S -s http://localhost:8983/solr/pahma-osteology/update --data '<optimize/>' -H 'Content-type:text/xml; charset=utf-8'
 time curl -S -s http://localhost:8983/solr/pahma-public/update --data '<optimize/>' -H 'Content-type:text/xml; charset=utf-8'
 time curl -S -s http://localhost:8983/solr/ucjeps-media/update --data '<optimize/>' -H 'Content-type:text/xml; charset=utf-8'
 time curl -S -s http://localhost:8983/solr/ucjeps-public/update --data '<optimize/>' -H 'Content-type:text/xml; charset=utf-8'

--- a/utilities/wget4solr.sh
+++ b/utilities/wget4solr.sh
@@ -19,7 +19,6 @@ wget https://webapps.cspace.berkeley.edu/4solr.pahma.allmedia.csv.gz
 #wget https://webapps.cspace.berkeley.edu/4solr.pahma.internal.csv.gz
 wget https://webapps.cspace.berkeley.edu/4solr.pahma.locations.csv.gz
 wget https://webapps.cspace.berkeley.edu/4solr.pahma.media.csv.gz
-wget https://webapps.cspace.berkeley.edu/4solr.pahma.osteology.csv.gz
 wget https://webapps.cspace.berkeley.edu/4solr.pahma.public.csv.gz
 wget https://webapps.cspace.berkeley.edu/4solr.ucjeps.media.csv.gz
 wget https://webapps.cspace.berkeley.edu/4solr.ucjeps.public.csv.gz


### PR DESCRIPTION
pahma/solrETL-internal.sh
pahma/solrETL-public.sh
pahma/solrETL-osteology.sh: no changes – check cron jobs to remove any jobs running osteology extract on blacklight.
solr-cores/addfield2solr.sh
solr-cores/makesolrcores.sh
solr-cores/legacy/make_cores.sh
solr-cores/legacy/make_schema.sh
solr-cores/legacy/solr.xml
utilities/allcurls.sh.example: no changes – sample command file.
utilities/checkcores.sh
utilities/checkstatus.sh
utilities/curl4solr.sh
utilities/make_curls.sh
utilities/oj.pahma.sh
utilities/optimize.sh
utilities/wget4solr.sh