### PR TITLE
HMP-292: Fix clause for objectcounttype 'piece count'

### DIFF
--- a/pahma/basic_all.sql
+++ b/pahma/basic_all.sql
@@ -3,8 +3,8 @@ SELECT DISTINCT ON (cc.objectnumber)
     hcc.name                                                            AS csid_s,
     cp.sortableobjectnumber                                             AS objsortnum_s,
     cc.objectnumber                                                     AS objmusno_s,
-    getdispl(cp.pahmatmslegacydepartment)                               AS objdept_s,
-    getdispl(cc.collection)                                             AS objtype_s,
+    GETDISPL(cp.pahmatmslegacydepartment)                               AS objdept_s,
+    GETDISPL(cc.collection)                                             AS objtype_s,
     ocg.objectcount                                                     AS objcount_s,
     ocg.objectcountnote                                                 AS objcountnote_s,
     cp.portfolioseries                                                  AS objkeelingser_s,
@@ -18,8 +18,9 @@ FROM collectionobjects_common cc
     LEFT OUTER JOIN hierarchy hocg ON (
         cc.id = hocg.parentid
         AND hocg.primarytype = 'objectCountGroup')
-    LEFT OUTER JOIN objectcountgroup ocg ON (hocg.id = ocg.id)
-WHERE getdispl(ocg.objectcounttype) = 'piece count'
+    LEFT OUTER JOIN objectcountgroup ocg ON (
+        hocg.id = ocg.id
+        AND GETDISPL(ocg.objectcounttype) = 'piece count')
 ORDER BY 
     cc.objectnumber,
     ocg.objectcountdate

--- a/pahma/basic_restricted.sql
+++ b/pahma/basic_restricted.sql
@@ -16,7 +16,8 @@ FROM collectionobjects_common cc
     JOIN hierarchy hcc ON (hcc.id = cc.id)
     LEFT OUTER JOIN collectionobjects_pahma cp ON (cp.id = cc.id)
     LEFT OUTER JOIN hierarchy hocg ON (
-        cc.id = hocg.parentid AND hocg.primarytype = 'objectCountGroup')
+        cc.id = hocg.parentid
+        AND hocg.primarytype = 'objectCountGroup')
     LEFT OUTER JOIN objectcountgroup ocg ON (
         hocg.id = ocg.id
         AND GETDISPL(ocg.objectcounttype) = 'piece count')

--- a/pahma/basic_restricted.sql
+++ b/pahma/basic_restricted.sql
@@ -3,8 +3,8 @@ SELECT DISTINCT ON (cc.objectnumber)
     hcc.name                                                            AS csid_s,
     cp.sortableobjectnumber                                             AS objsortnum_s,
     cc.objectnumber                                                     AS objmusno_s,
-    getdispl(cp.pahmatmslegacydepartment)                               AS objdept_s,
-    getdispl(cc.collection)                                             AS objtype_s,
+    GETDISPL(cp.pahmatmslegacydepartment)                               AS objdept_s,
+    GETDISPL(cc.collection)                                             AS objtype_s,
     ocg.objectcount                                                     AS objcount_s,
     ocg.objectcountnote                                                 AS objcountnote_s,
     cp.portfolioseries                                                  AS objkeelingser_s,
@@ -15,11 +15,13 @@ FROM collectionobjects_common cc
         AND misc.lifecyclestate <> 'deleted')
     JOIN hierarchy hcc ON (hcc.id = cc.id)
     LEFT OUTER JOIN collectionobjects_pahma cp ON (cp.id = cc.id)
-    LEFT OUTER JOIN hierarchy hocg ON (cc.id = hocg.parentid AND hocg.primarytype = 'objectCountGroup')
-    LEFT OUTER JOIN objectcountgroup ocg ON (hocg.id = ocg.id)
+    LEFT OUTER JOIN hierarchy hocg ON (
+        cc.id = hocg.parentid AND hocg.primarytype = 'objectCountGroup')
+    LEFT OUTER JOIN objectcountgroup ocg ON (
+        hocg.id = ocg.id
+        AND GETDISPL(ocg.objectcounttype) = 'piece count')
     LEFT OUTER JOIN collectionobjects_pahma_pahmaobjectstatuslist osl ON (cc.id = osl.id)
-WHERE getdispl(ocg.objectcounttype) = 'piece count'
-AND getdispl(osl.item) IN (
+WHERE GETDISPL(osl.item) IN (
     'accessioned',
     'deaccessioned',
     'number not used',

--- a/pahma/locations2.sql
+++ b/pahma/locations2.sql
@@ -23,8 +23,9 @@ FROM collectionobjects_common cc
     LEFT OUTER JOIN hierarchy hocg ON (
         cc.id = hocg.parentid
         AND hocg.primarytype = 'objectCountGroup')
-    LEFT OUTER JOIN objectcountgroup ocg ON (hocg.id = ocg.id)
-WHERE getdispl(ocg.objectcounttype) = 'piece count'
+    LEFT OUTER JOIN objectcountgroup ocg ON (
+        hocg.id = ocg.id
+        AND GETDISPL(ocg.objectcounttype) = 'piece count')
 ORDER BY 
     cc.objectnumber,
     ocg.objectcountdate


### PR DESCRIPTION
distinct on objectnumber produces count difference because of duplicate objectnumber records, i.e.,
different collectionobjects_common.id, but same collectionobjects_common.objectnumber.