### PR TITLE
CSW-998: update solr queries and bampfa_collectionitems_vw for consistency/efficiency

### DIFF
--- a/bampfa/bampfa_collectionitems_vw.sql
+++ b/bampfa/bampfa_collectionitems_vw.sql
@@ -1,157 +1,220 @@
--- bampfa_collectionitems_vw.sql
--- View used to get live data in support of several functions, including Inject Metadata
--- CRH 10/22/2014
--- CRH 10/27/2014 Measurements subst hyphen with space. Utils schema.
--- CRH 11/25/2014 Added artistDisplayOverride
--- CRH 04/25/2015 Added several fields; see Jira BAMPFA-402
--- CRH 7/30/2015 Added Acquisition Method BAMPFA-446
--- LKV 9/28/2016 BAMPFA-507; Added call to new function utils.get_first_blobcsid_displevel to get
---     first image blob csid (image1blobcsid) and website display level (image1displevel) for all images.
--- LKV 10/27/2016 BAMPFA-512; Added new field 'image_count' using new function utils.get_object_image_count; dropped and recreated view.
+/* bampfa_collectionitems_vw.sql
+ *  View used to get live data in support of several functions, including Inject Metadata
+ *  CRH 10/22/2014
+ *  CRH 10/27/2014 Measurements subst hyphen with space. Utils schema.
+ *  CRH 11/25/2014 Added artistDisplayOverride
+ *  CRH 04/25/2015 Added several fields; see Jira BAMPFA-402
+ *  CRH 07/30/2015 Added Acquisition Method BAMPFA-446
+ *  LKV 09/28/2016 BAMPFA-507: Add call to new function utils.get_first_blobcsid_displevel to
+      get first image blob csid (image1blobcsid)
+      and website display level (image1displevel) for all images.
+ *  LKV 10/27/2016 BAMPFA-512: Added new field 'image_count' using new function utils.get_object_image_count
+ *  LKV 05/26/2026 CSW-998:
+      update query to match metadata_public.sql
+      remove extraneous join to collectionspace_core
+      NOTE: site data source is different from Solr metadata queries, ie objectproductionplace vs assocplace
+*/
 
--- drop view utils.bampfa_collectionitems_vw
+-- DROP VIEW utils.bampfa_collectionitems_vw
 
-create or replace view utils.bampfa_collectionitems_vw as
+CREATE OR REPLACE VIEW utils.bampfa_collectionitems_vw AS
+WITH subjectthemes AS (	-- get first five subjectthemes
+  SELECT
+    id,
+    MAX(CASE WHEN pos = 0 THEN GETDISPL(item) END) AS SubjectOne,
+    MAX(CASE WHEN pos = 1 THEN GETDISPL(item) END) AS SubjectTwo,
+    MAX(CASE WHEN pos = 2 THEN GETDISPL(item) END) AS SubjectThree,
+    MAX(CASE WHEN pos = 3 THEN GETDISPL(item) END) AS SubjectFour,
+    MAX(CASE WHEN pos = 4 THEN GETDISPL(item) END) AS SubjectFive
+  FROM collectionobjects_bampfa_subjectthemes
+  WHERE pos < 5
+  GROUP BY id
+),
+
+collections AS (	-- get first 3 collections
+  SELECT
+    id,
+    MAX(CASE WHEN pos = 0 THEN GETDISPL(item) END) AS collection1,
+    MAX(CASE WHEN pos = 1 THEN GETDISPL(item) END) AS collection2,
+    MAX(CASE WHEN pos = 2 THEN GETDISPL(item) END) AS collection3
+  FROM collectionobjects_bampfa_bampfacollectionlist
+  WHERE pos < 3
+  GROUP BY id
+),
+
+periodstyles AS (	-- get first 5 periodstyles
+  SELECT
+    id,
+    MAX(CASE WHEN pos = 0 THEN GETDISPL(item) END) AS periodstyle1,
+    MAX(CASE WHEN pos = 1 THEN GETDISPL(item) END) AS periodstyle2,
+    MAX(CASE WHEN pos = 2 THEN GETDISPL(item) END) AS periodstyle3,
+    MAX(CASE WHEN pos = 3 THEN GETDISPL(item) END) AS periodstyle4,
+    MAX(CASE WHEN pos = 4 THEN GETDISPL(item) END) AS periodstyle5
+  FROM collectionobjects_common_styles
+  WHERE pos < 5
+  GROUP BY id
+)
+
 SELECT
-   h1.name objectCSID,
-   co.objectnumber idNumber,
-   cb.sortableEffectiveObjectNumber sortObjectNumber,
-   con.numbervalue otherNumber,
-   utils.getdispl(cb.itemclass) itemclass,
-   case when (cb.artistdisplayoverride is null or cb.artistdisplayoverride='') then utils.concat_artists(h1.name)
-     else cb.artistdisplayoverride end as artistCalc,
-   case
-     when (pc.birthplace is null or pc.birthplace='') then pcn.item
-     when (pcn.item = pc.birthplace) then pcn.item
-     else pcn.item||', born '||pc.birthplace end
-   as artistorigin,
-   sdgpb.datedisplaydate artistbirthdate,
-   sdgpd.datedisplaydate artistdeathdate,
-   pb.datesactive,
-   bt.bampfatitle title,
-   cb.initialvalue,
-   cv.currentvalue,
-   cv.currentvaluesource,
-   sdgcv.datedisplaydate currentvaluedate,
-   cb.creditline, 
-   case when (cb.creditline='' or cb.creditline is null)  then
-     'University of California, Berkeley Art Museum and Pacific Film Archive'
-     else 'University of California, Berkeley Art Museum and Pacific Film Archive; '||cb.creditline
-   end as fullBAMPFAcreditline,
-   case when (cb.permissiontoreproduce is null or cb.permissiontoreproduce='') then pb.permissiontoreproduce
-      else cb.permissiontoreproduce end as permissiontoreproduce,
-   case when (cb.copyrightCredit is null or cb.copyrightCredit='') then pb.copyrightCredit
-      else cb.copyrightCredit end as copyrightCredit,
-   cb.photoCredit,
-   sdg.datedisplaydate dateMade,
-   replace(mp.dimensionsummary, '-', ' ') measurement,
-   co.physicaldescription materials,
-   sdgac.datedisplaydate dateacquired, -- in future will need case statements to get from intake
-   getdispl(cas.item) acquisitionsource,
-   cb.provenance,
-   sg.inscriptioncontent signature,
-   ccom.item notescomments,
-   cg.catalogername cataloger,
-   cg.catalognote catalognote,
-   cg.catalogdate,
-   case when (pp.objectproductionplace is not null and pp.objectproductionplace<>'') then pp.objectproductionplace
-      else null
-   end as site,
-   utils.getdispl(st1.item) SubjectOne,
-   utils.getdispl(st2.item) SubjectTwo,
-   utils.getdispl(st3.item) SubjectThree,
-   utils.getdispl(st4.item) SubjectFour,
-   utils.getdispl(st5.item) SubjectFive,
-   utils.getdispl(co.computedcurrentlocation) currentlocation,
-   utils.getdispl(cb.computedcrate) currentcrate,
-   utils.getdispl(col1.item) collection1,
-   utils.getdispl(col2.item) collection2,
-   utils.getdispl(col3.item) collection3,
-   utils.getdispl(ps1.item) periodstyle1,
-   utils.getdispl(ps2.item) periodstyle2,
-   utils.getdispl(ps3.item) periodstyle3,
-   utils.getdispl(ps4.item) periodstyle4,
-   utils.getdispl(ps5.item) periodstyle5,
-   utils.getdispl(cb.legalstatus) legalstatus,
-   utils.get_object_image_count(h1.name) imagecount,
-   utils.get_first_blobcsid_displevel(h1.name, 'blobcsid') image1blobcsid,
-   utils.get_first_blobcsid_displevel(h1.name, 'displevel') image1displevel,
-   utils.getdispl(cb.acquisitionmethod) acquisitionmethod
-from
-   hierarchy h1
-   INNER JOIN collectionobjects_common co
-      ON (h1.id = co.id AND h1.primarytype = 'CollectionObjectTenant55')
-   INNER JOIN misc m
-      ON (co.id = m.id AND m.lifecyclestate <> 'deleted')
-   INNER JOIN collectionobjects_bampfa cb
-      ON (co.id = cb.id)
-   INNER JOIN collectionspace_core core on co.id=core.id
-   LEFT OUTER JOIN hierarchy h2
-      ON (h2.parentid = co.id AND h2.name='collectionobjects_common:objectProductionDateGroupList' and h2.pos=0)
-   LEFT OUTER JOIN structuredDateGroup sdg ON (h2.id = sdg.id)
-   LEFT OUTER JOIN hierarchy h3
-      ON (h3.parentid = co.id AND h3.name = 'collectionobjects_common:otherNumberList' and h3.pos=0)
-   LEFT OUTER JOIN othernumber con
-      ON (h3.id = con.id)
-   LEFT OUTER JOIN hierarchy h4
-      ON (h4.parentid = co.id AND h4.name = 'collectionobjects_bampfa:bampfaTitleGroupList' and h4.pos=0)
-   LEFT OUTER JOIN bampfatitlegroup bt
-      ON (h4.id = bt.id)
-   LEFT OUTER JOIN hierarchy h5
-      ON (h5.parentid = co.id AND h5.name = 'collectionobjects_bampfa:currentValueGroupList' and h5.pos=0)
-   LEFT OUTER JOIN currentvaluegroup cv
-      ON (h5.id = cv.id)  
-   LEFT OUTER JOIN hierarchy h6
-      ON (h6.parentid = cv.id AND h6.name='currentValueDateGroup')
-   LEFT OUTER JOIN structuredDateGroup sdgcv ON (h6.id = sdgcv.id)
-   LEFT OUTER JOIN hierarchy h7
-      ON (h7.parentid = co.id AND h7.name = 'collectionobjects_common:measuredPartGroupList' and h7.pos=0)
-   LEFT OUTER JOIN measuredpartgroup mp
-      ON (h7.id = mp.id)
-   LEFT OUTER JOIN hierarchy h8
-      ON (h8.parentid = co.id AND h8.name = 'collectionobjects_common:textualInscriptionGroupList' and h8.pos=0)
-   LEFT OUTER JOIN textualinscriptiongroup sg
-      ON (h8.id = sg.id)
-   LEFT OUTER JOIN hierarchy h9
-      ON (h9.parentid = co.id AND h9.name='collectionobjects_bampfa:acquisitionDateGroupList' and h9.pos=0)
-   LEFT OUTER JOIN structuredDateGroup sdgac ON (h9.id = sdgac.id)
-   LEFT OUTER JOIN collectionobjects_bampfa_acquisitionsources cas on (co.id=cas.id and cas.pos=0)
-   LEFT OUTER JOIN collectionobjects_common_comments ccom on (co.id=ccom.id and ccom.pos=0)
-   LEFT OUTER JOIN hierarchy h10
-      ON (h10.parentid = co.id AND h10.name = 'collectionobjects_bampfa:catalogerGroupList' and h10.pos=0)
-   LEFT OUTER JOIN catalogergroup cg
-      ON (h10.id = cg.id)
-   LEFT OUTER JOIN hierarchy h11
-      ON (h11.parentid = co.id AND h11.name = 'collectionobjects_bampfa:bampfaObjectProductionPersonGroupList' and h11.pos=0)
-   LEFT OUTER JOIN bampfaobjectproductionpersongroup ba
-      ON (h11.id = ba.id)  
-   LEFT OUTER JOIN persons_common pc on (ba.bampfaobjectproductionperson=pc.refname)
-   LEFT OUTER JOIN persons_common_nationalities pcn on (pc.id=pcn.id and pcn.pos=0)
-   LEFT OUTER JOIN hierarchy h12
-      ON (h12.parentid = pc.id AND h12.name='persons_common:birthDateGroup')
-   LEFT OUTER JOIN structuredDateGroup sdgpb ON (h12.id = sdgpb.id)
-   LEFT OUTER JOIN hierarchy h13
-      ON (h13.parentid = pc.id AND h13.name='persons_common:deathDateGroup')
-   LEFT OUTER JOIN structuredDateGroup sdgpd ON (h13.id = sdgpd.id)
-   LEFT OUTER JOIN persons_bampfa pb on (pc.id=pb.id)
-   LEFT OUTER JOIN hierarchy h14
-      ON (h14.parentid = co.id AND h14.name = 'collectionobjects_common:objectProductionPlaceGroupList' and h14.pos=0)
-   LEFT OUTER JOIN objectproductionplacegroup pp
-      ON (h14.id = pp.id)
-   LEFT OUTER JOIN collectionobjects_bampfa_subjectthemes st1 ON (st1.id=co.id and st1.pos=0)
-   LEFT OUTER JOIN collectionobjects_bampfa_subjectthemes st2 ON (st2.id=co.id and st2.pos=1)
-   LEFT OUTER JOIN collectionobjects_bampfa_subjectthemes st3 ON (st3.id=co.id and st3.pos=2)
-   LEFT OUTER JOIN collectionobjects_bampfa_subjectthemes st4 ON (st4.id=co.id and st4.pos=3)
-   LEFT OUTER JOIN collectionobjects_bampfa_subjectthemes st5 ON (st5.id=co.id and st5.pos=4)
-   LEFT OUTER JOIN collectionobjects_bampfa_bampfacollectionlist col1 ON (col1.id=co.id and col1.pos=0)
-   LEFT OUTER JOIN collectionobjects_bampfa_bampfacollectionlist col2 ON (col2.id=co.id and col2.pos=1)
-   LEFT OUTER JOIN collectionobjects_bampfa_bampfacollectionlist col3 ON (col3.id=co.id and col2.pos=2)
-   LEFT OUTER JOIN collectionobjects_common_styles ps1 ON (ps1.id=co.id and ps1.pos=0)
-   LEFT OUTER JOIN collectionobjects_common_styles ps2 ON (ps2.id=co.id and ps2.pos=1)
-   LEFT OUTER JOIN collectionobjects_common_styles ps3 ON (ps3.id=co.id and ps3.pos=2)
-   LEFT OUTER JOIN collectionobjects_common_styles ps4 ON (ps4.id=co.id and ps4.pos=3)
-   LEFT OUTER JOIN collectionobjects_common_styles ps5 ON (ps5.id=co.id and ps5.pos=4)
-order by cb.sortableEffectiveObjectNumber;
+  hcc.name AS objectCSID,
+  cc.objectnumber AS idNumber,
+  cb.sortableEffectiveObjectNumber AS sortObjectNumber,
+  con.numbervalue AS otherNumber,
+  GETDISPL(cb.itemclass) AS itemclass,
+  COALESCE(NULLIF(cb.artistdisplayoverride, ''), UTILS.CONCAT_ARTISTS(hcc.name)) AS artistCalc,
+  CASE
+    WHEN NULLIF(pc.birthplace, '') IS NULL THEN pcn.item
+    WHEN pcn.item = pc.birthplace THEN pcn.item
+    ELSE pcn.item || ', born '|| pc.birthplace END AS artistorigin,
+  bdg.datedisplaydate AS artistbirthdate,
+  ddg.datedisplaydate AS artistdeathdate,
+  pb.datesactive,
+  btg.bampfatitle AS title,
+  cb.initialvalue,
+  cvg.currentvalue,
+  cvg.currentvaluesource,
+  cvdg.datedisplaydate AS currentvaluedate,
+  cb.creditline,
+  'University of California, Berkeley Art Museum and Pacific Film Archive'
+    || COALESCE('; '|| cb.creditline, '') AS fullBAMPFAcreditline,
+  COALESCE(NULLIF(cb.permissiontoreproduce, ''), pb.permissiontoreproduce) AS permissiontoreproduce,
+  COALESCE(NULLIF(cb.copyrightCredit, ''), pb.copyrightCredit) AS copyrightCredit,
+  cb.photoCredit,
+  pdg.datedisplaydate AS dateMade,
+  REPLACE(mpg.dimensionsummary, '-', ' ') AS measurement,
+  cc.physicaldescription AS materials,
+  adg.datedisplaydate AS dateacquired,	-- in future will need case statements to get from intake
+  GETDISPL(cbas.item) AS acquisitionsource,
+  cb.provenance,
+  tig.inscriptioncontent AS signature,
+  TRIM(REGEXP_REPLACE(ccc.item, '[[:space:]]+', ' ', 'g')) AS notescomments,	-- replace CRLF w/space then trim
+  cg.catalogername AS cataloger,
+  cg.catalognote AS catalognote,
+  cg.catalogdate,
+  NULLIF(pplg.objectproductionplace, '') AS site,	-- from apg.assocplace in metadata_internal.sql,
+  st.SubjectOne,
+  st.SubjectTwo,
+  st.SubjectThree,
+  st.SubjectFour,
+  st.SubjectFive,
+  GETDISPL(cc.computedcurrentlocation) AS currentlocation,
+  GETDISPL(cb.computedcrate) AS currentcrate,
+  c.collection1,
+  c.collection2,
+  c.collection3,
+  ps.periodstyle1,
+  ps.periodstyle2,
+  ps.periodstyle3,
+  ps.periodstyle4,
+  ps.periodstyle5,
+  GETDISPL(cb.legalstatus) AS legalstatus,
+  UTILS.GET_OBJECT_IMAGE_COUNT(hcc.name) AS imagecount,
+  UTILS.GET_FIRST_BLOBCSID_DISPLEVEL(hcc.name, 'blobcsid') AS image1blobcsid,
+  UTILS.GET_FIRST_BLOBCSID_DISPLEVEL(hcc.name, 'displevel') AS image1displevel,
+  GETDISPL(cb.acquisitionmethod) AS acquisitionmethod
 
-grant select on utils.bampfa_collectionitems_vw to reader_bampfa;
-grant select on utils.bampfa_collectionitems_vw to group reporters_bampfa;
+FROM collectionobjects_common cc
+  JOIN hierarchy hcc ON cc.id = hcc.id
+  JOIN misc mcc ON cc.id = mcc.id
+  JOIN collectionobjects_bampfa cb ON cc.id = cb.id
+
+  LEFT OUTER JOIN hierarchy hpdg	-- get first production date
+    ON cc.id = hpdg.parentid
+    AND hpdg.name = 'collectionobjects_common:objectProductionDateGroupList'
+    AND hpdg.pos = 0
+  LEFT OUTER JOIN structuredDateGroup pdg ON hpdg.id = pdg.id
+
+  LEFT OUTER JOIN hierarchy hcon	-- get first other number
+    ON cc.id = hcon.parentid
+    AND hcon.name = 'collectionobjects_common:otherNumberList'
+    AND hcon.pos = 0
+  LEFT OUTER JOIN othernumber con ON hcon.id = con.id
+
+  LEFT OUTER JOIN hierarchy hbtg	-- get first title
+    ON cc.id = hbtg.parentid
+    AND hbtg.name = 'collectionobjects_bampfa:bampfaTitleGroupList'
+    AND hbtg.pos = 0
+  LEFT OUTER JOIN bampfatitlegroup btg ON hbtg.id = btg.id
+
+  LEFT OUTER JOIN hierarchy hcvg	-- get first current value
+    ON cc.id = hcvg.parentid
+    AND hcvg.name = 'collectionobjects_bampfa:currentValueGroupList'
+    AND hcvg.pos = 0
+  LEFT OUTER JOIN currentvaluegroup cvg ON hcvg.id = cvg.id
+
+  LEFT OUTER JOIN hierarchy hcvdg	-- get first current value date
+    ON cvg.id = hcvdg.parentid
+    AND hcvdg.name = 'currentValueDateGroup'
+  LEFT OUTER JOIN structuredDateGroup cvdg ON hcvdg.id = cvdg.id
+
+  LEFT OUTER JOIN hierarchy hmpg	-- get first measured part
+    ON cc.id = hmpg.parentid
+    AND hmpg.name = 'collectionobjects_common:measuredPartGroupList'
+    AND hmpg.pos = 0
+  LEFT OUTER JOIN measuredpartgroup mpg ON hmpg.id = mpg.id
+
+  LEFT OUTER JOIN hierarchy htig	-- get first signature
+    ON cc.id = htig.parentid
+    AND htig.name = 'collectionobjects_common:textualInscriptionGroupList'
+    AND htig.pos = 0
+  LEFT OUTER JOIN textualinscriptiongroup tig ON htig.id = tig.id
+
+  LEFT OUTER JOIN hierarchy hadg	-- get first acquisition date
+    ON cc.id = hadg.parentid
+    AND hadg.name = 'collectionobjects_bampfa:acquisitionDateGroupList'
+    AND hadg.pos = 0
+  LEFT OUTER JOIN structuredDateGroup adg ON hadg.id = adg.id
+
+  LEFT OUTER JOIN collectionobjects_bampfa_acquisitionsources cbas	-- get first acquisition source
+    ON cc.id = cbas.id
+    AND cbas.pos = 0
+
+  LEFT OUTER JOIN collectionobjects_common_comments ccc	-- get first collection object comment
+    ON cc.id = ccc.id
+    AND ccc.pos = 0
+
+  LEFT OUTER JOIN hierarchy hcg	-- get first cataloger
+    ON cc.id = hcg.parentid
+    AND hcg.name = 'collectionobjects_bampfa:catalogerGroupList'
+    AND hcg.pos = 0
+  LEFT OUTER JOIN catalogergroup cg ON hcg.id = cg.id
+
+  LEFT OUTER JOIN hierarchy hppg	-- get first artist
+    ON cc.id = hppg.parentid
+    AND hppg.name = 'collectionobjects_bampfa:bampfaObjectProductionPersonGroupList'
+    AND hppg.pos = 0
+  LEFT OUTER JOIN bampfaobjectproductionpersongroup ppg ON hppg.id = ppg.id
+  LEFT OUTER JOIN persons_common pc ON ppg.bampfaobjectproductionperson = pc.refname
+
+  LEFT OUTER JOIN persons_common_nationalities pcn	-- get first nationality of first artist
+    ON pc.id = pcn.id
+    AND pcn.pos = 0
+
+  LEFT OUTER JOIN persons_bampfa pb ON pc.id = pb.id	-- get active dates, permissions, copyright for first artist
+
+  LEFT OUTER JOIN hierarchy hbdg	-- get birth date of first artist
+    ON pc.id = hbdg.parentid
+    AND hbdg.name = 'persons_common:birthDateGroup'
+  LEFT OUTER JOIN structuredDateGroup bdg ON hbdg.id = bdg.id
+
+  LEFT OUTER JOIN hierarchy hddg	-- get death date of first artist
+    ON pc.id = hddg.parentid
+    AND hddg.name = 'persons_common:deathDateGroup'
+  LEFT OUTER JOIN structuredDateGroup ddg ON hddg.id = ddg.id
+
+  LEFT OUTER JOIN hierarchy hpplg	-- get first production place
+    ON cc.id = hpplg.parentid
+    AND hpplg.name = 'collectionobjects_common:objectProductionPlaceGroupList'
+    AND hpplg.pos = 0
+  LEFT OUTER JOIN objectproductionplacegroup pplg ON hpplg.id = pplg.id
+
+  LEFT OUTER JOIN subjectthemes st ON cc.id = st.id	-- get subjects
+  LEFT OUTER JOIN collections c ON cc.id = c.id	-- get collections
+  LEFT OUTER JOIN periodstyles ps ON cc.id = ps.id	-- get periodstyles
+
+WHERE mcc.lifecyclestate <> 'deleted'	-- exclude deleted objects
+ORDER BY cb.sortableEffectiveObjectNumber;
+
+
+GRANT SELECT ON utils.bampfa_collectionitems_vw TO reader_bampfa;
+GRANT SELECT ON utils.bampfa_collectionitems_vw TO group reporters_bampfa;

--- a/bampfa/media_internal.sql
+++ b/bampfa/media_internal.sql
@@ -1,29 +1,45 @@
+/*
+-- media_internal.sql
+--
+-- get collection objects with media and blob data, where relations, objects, media, and blobs are not deleted.
+*/
+
 SELECT 
-h2.name objectcsid,
-cc.objectnumber,
-h1.name mediacsid,
-mc.description,
-b.name,
-mc.creator creatorRefname,
-mc.creator creator,
-mc.blobcsid,
-mc.copyrightstatement,
-mc.identificationnumber,
-mc.rightsholder rightsholderRefname,
-mc.rightsholder rightsholder,
-mc.contributor,
-mb.imageNumber
+  hcc.name AS objectcsid,
+  cc.objectnumber,
+  hmc.name AS mediacsid,
+  mc.description,
+  bc.name,
+  mc.creator AS creatorRefname,
+  mc.creator AS creator,
+  mc.blobcsid,
+  mc.copyrightstatement,
+  mc.identificationnumber,
+  mc.rightsholder AS rightsholderRefname,
+  mc.rightsholder AS rightsholder,
+  mc.contributor,
+  mb.imageNumber
 
-FROM media_common mc
+FROM relations_common rc
+  JOIN misc mrc on rc.id = mrc.id	-- exclude deleted relations
 
-LEFT OUTER JOIN media_bampfa mb on (mb.id = mc.id)
-JOIN misc ON (mc.id = misc.id AND misc.lifecyclestate <> 'deleted')
-LEFT OUTER JOIN hierarchy h1 ON (h1.id = mc.id)
-INNER JOIN relations_common r on (h1.name = r.objectcsid)
-LEFT OUTER JOIN hierarchy h2 on (r.subjectcsid = h2.name)
-LEFT OUTER JOIN collectionobjects_common cc on (h2.id = cc.id)
+  JOIN hierarchy hcc ON rc.objectcsid = hcc.name
+  JOIN collectionobjects_common cc ON hcc.id = cc.id
+  JOIN misc mcc on cc.id = mcc.id	-- eclude deleted collection objects
 
-JOIN hierarchy h3 ON (mc.blobcsid = h3.name)
-LEFT OUTER JOIN blobs_common b on (h3.id = b.id)
+  JOIN hierarchy hmc ON rc.subjectcsid = hmc.name
+  JOIN media_common mc ON hmc.id = mc.id
+  JOIN misc mmc ON mc.id = mmc.id	-- exclude deleted media
+
+  JOIN hierarchy hbc ON mc.blobcsid = hbc.name
+  JOIN blobs_common bc on (hbc.id = bc.id)
+  JOIN misc mbc ON bc.id = mbc.id	-- exclude deleted blobs
+
+  LEFT OUTER JOIN media_bampfa mb ON mc.id = mb.id
+
+WHERE mrc.lifecyclestate <> 'deleted'
+AND mcc.lifecyclestate <> 'deleted'
+AND mmc.lifecyclestate <> 'deleted'
+AND mbc.lifecyclestate <> 'deleted'
 
 ORDER BY mb.imageNumber ASC

--- a/bampfa/media_public.sql
+++ b/bampfa/media_public.sql
@@ -1,30 +1,47 @@
+/*
+-- media_public.sql
+--
+-- get collection objects with media and blob data, where relations, objects, media, and blobs are not deleted.
+-- and not flagged for 'No public display'
+*/
+
 SELECT 
-h2.name objectcsid,
-cc.objectnumber,
-h1.name mediacsid,
-mc.description,
-b.name,
-mc.creator creatorRefname,
-mc.creator creator,
-mc.blobcsid,
-mc.copyrightstatement,
-mc.identificationnumber,
-mc.rightsholder rightsholderRefname,
-mc.rightsholder rightsholder,
-mc.contributor,
-mb.imageNumber
+  hcc.name AS objectcsid,
+  cc.objectnumber,
+  hmc.name AS mediacsid,
+  mc.description,
+  bc.name,
+  mc.creator AS creatorRefname,
+  mc.creator AS creator,
+  mc.blobcsid,
+  mc.copyrightstatement,
+  mc.identificationnumber,
+  mc.rightsholder AS rightsholderRefname,
+  mc.rightsholder AS rightsholder,
+  mc.contributor,
+  mb.imageNumber
 
-FROM media_common mc
+FROM relations_common rc
+  JOIN misc mrc on rc.id = mrc.id
 
-LEFT OUTER JOIN media_bampfa mb ON (mb.id = mc.id)
-JOIN misc ON (mc.id = misc.id AND misc.lifecyclestate <> 'deleted')
-LEFT OUTER JOIN hierarchy h1 ON (h1.id = mc.id)
-INNER JOIN relations_common r ON (h1.name = r.objectcsid)
-LEFT OUTER JOIN hierarchy h2 ON (r.subjectcsid = h2.name)
-LEFT OUTER JOIN collectionobjects_common cc ON (h2.id = cc.id)
+  JOIN hierarchy hcc ON rc.objectcsid = hcc.name
+  JOIN collectionobjects_common cc ON hcc.id = cc.id
+  JOIN misc mcc on cc.id = mcc.id
 
-JOIN hierarchy h3 ON (mc.blobcsid = h3.name)
-LEFT OUTER JOIN blobs_common b ON (h3.id = b.id)
-WHERE mb.websitedisplaylevel IS DISTINCT FROM 'No public display'
+  JOIN hierarchy hmc ON rc.subjectcsid = hmc.name
+  JOIN media_common mc ON hmc.id = mc.id
+  JOIN misc mmc ON mc.id = mmc.id
+
+  JOIN hierarchy hbc ON mc.blobcsid = hbc.name
+  JOIN blobs_common bc on hbc.id = bc.id
+  JOIN misc mbc ON bc.id = mbc.id
+
+  LEFT OUTER JOIN media_bampfa mb ON mc.id = mb.id
+
+WHERE mrc.lifecyclestate <> 'deleted'	-- exclude deleted relations
+  AND mcc.lifecyclestate <> 'deleted'	-- exclude deleted collection objects
+  AND mmc.lifecyclestate <> 'deleted'	-- exclude deleted media
+  AND mbc.lifecyclestate <> 'deleted'	-- exclude deleted blobs
+  AND mb.websitedisplaylevel IS DISTINCT FROM 'No public display'	-- include public display media records
 
 ORDER BY mb.imageNumber ASC

--- a/bampfa/metadata_internal.sql
+++ b/bampfa/metadata_internal.sql
@@ -1,130 +1,192 @@
-select
-   h1.name objectCSID,
-   co.objectnumber idNumber,
-   cb.sortableEffectiveObjectNumber sortObjectNumber,
-   con.numbervalue otherNumber,
-   utils.getdispl(cb.itemclass) itemclass,
-   case when (cb.artistdisplayoverride is null or cb.artistdisplayoverride='') then utils.concat_artists(h1.name)
-     else cb.artistdisplayoverride end as artistCalc,
---   getdispl(ba.bampfaobjectproductionperson) artist,
-   case
-     when (pc.birthplace is null or pc.birthplace='') then pcn.item
-     when (pcn.item = pc.birthplace) then pcn.item
-     else pcn.item||', born '||pc.birthplace end
-   as artistorigin,
-   sdgpb.datedisplaydate artistbirthdate,
-   sdgpd.datedisplaydate artistdeathdate,
-   pb.datesactive,
-   bt.bampfatitle title,
-   -- not included, for now
-   -- cb.initialvalue,
-   -- cv.currentvalue,
-   '-REDACTED-' as initialvalue,
-   '-REDACTED-' as currentvalue,
-   cv.currentvaluesource,
-   sdgcv.datedisplaydate currentvaluedate,
-   cb.creditline,
-   case when (cb.creditline='' or cb.creditline is null)  then
-     'University of California, Berkeley Art Museum and Pacific Film Archive'
-     else 'University of California, Berkeley Art Museum and Pacific Film Archive; '||cb.creditline
-   end as fullBAMPFAcreditline,
-   case when (cb.permissiontoreproduce is null or cb.permissiontoreproduce='') then pb.permissiontoreproduce
-      else cb.permissiontoreproduce end as permissiontoreproduce,
-   case when (cb.copyrightCredit is null or cb.copyrightCredit='') then pb.copyrightCredit
-      else cb.copyrightCredit end as copyrightCredit,
-   cb.photoCredit,
-   sdg.datedisplaydate dateMade,
-   replace(mp.dimensionsummary, '-', ' ') measurement,
-   co.physicaldescription materials,
-   sdgac.datedisplaydate dateacquired, -- in future will need case statements to get from intake
-   getdispl(cas.item) acquisitionsource,
-   cb.provenance,
-   sg.inscriptioncontent signature,
-   ccom.item notescomments,
-   cg.catalogername cataloger,
-   cg.catalognote catalognote,
-   cg.catalogdate,
-   apg.assocplace site,
-   utils.getdispl(st1.item) SubjectOne,
-   utils.getdispl(st2.item) SubjectTwo,
-   utils.getdispl(st3.item) SubjectThree,
-   utils.getdispl(st4.item) SubjectFour,
-   utils.getdispl(st5.item) SubjectFive,
-   utils.getdispl(co.computedcurrentlocation) currentlocation,
-   utils.getdispl(cb.computedcrate) currentcrate,
-   TRIM(cb.objectProductionDateCentury || ' ' || regexp_replace(cb.objectProductionDateEra, '^.*\)''(.*)''$', '\1')) as century,
-   array_to_string(array
-      (SELECT CASE WHEN (gc.title IS NOT NULL AND gc.title <> '') THEN (gc.title) END
-       from collectionobjects_common co2
-       inner join hierarchy h2int on co2.id = h2int.id
-       join relations_common rc ON (h2int.name = rc.subjectcsid AND rc.objectdocumenttype = 'Group')
-       join hierarchy h16 ON (rc.objectcsid = h16.name)
-       left outer join groups_common gc ON (h16.id = gc.id)
-       join misc mm ON (gc.id=mm.id AND mm.lifecyclestate <> 'deleted')
-       where h2int.name = h1.name), ';', '') as grouptitle_ss
-from
-   hierarchy h1
-   INNER JOIN collectionobjects_common co
-      ON (h1.id = co.id AND h1.primarytype = 'CollectionObjectTenant55')
-   INNER JOIN misc m
-      ON (co.id = m.id AND m.lifecyclestate <> 'deleted')
-   INNER JOIN collectionobjects_bampfa cb
-      ON (co.id = cb.id)
-   INNER JOIN collectionspace_core core on co.id=core.id
-   LEFT OUTER JOIN hierarchy h2
-      ON (h2.parentid = co.id AND h2.name='collectionobjects_common:objectProductionDateGroupList' and h2.pos=0)
-   LEFT OUTER JOIN structuredDateGroup sdg ON (h2.id = sdg.id)
-   LEFT OUTER JOIN hierarchy h3
-      ON (h3.parentid = co.id AND h3.name = 'collectionobjects_common:otherNumberList' and h3.pos=0)
-   LEFT OUTER JOIN othernumber con
-      ON (h3.id = con.id)
-   LEFT OUTER JOIN hierarchy h4
-      ON (h4.parentid = co.id AND h4.name = 'collectionobjects_bampfa:bampfaTitleGroupList' and h4.pos=0)
-   LEFT OUTER JOIN bampfatitlegroup bt
-      ON (h4.id = bt.id)
-   LEFT OUTER JOIN hierarchy h5
-      ON (h5.parentid = co.id AND h5.name = 'collectionobjects_bampfa:currentValueGroupList' and h5.pos=0)
-   LEFT OUTER JOIN currentvaluegroup cv
-      ON (h5.id = cv.id)
-   LEFT OUTER JOIN hierarchy h6
-      ON (h6.parentid = cv.id AND h6.name='currentValueDateGroup')
-   LEFT OUTER JOIN structuredDateGroup sdgcv ON (h6.id = sdgcv.id)
-   LEFT OUTER JOIN hierarchy h7
-      ON (h7.parentid = co.id AND h7.name = 'collectionobjects_common:measuredPartGroupList' and h7.pos=0)
-   LEFT OUTER JOIN measuredpartgroup mp
-      ON (h7.id = mp.id)
-   LEFT OUTER JOIN hierarchy h8
-      ON (h8.parentid = co.id AND h8.name = 'collectionobjects_common:textualInscriptionGroupList' and h8.pos=0)
-   LEFT OUTER JOIN textualinscriptiongroup sg
-      ON (h8.id = sg.id)
-   LEFT OUTER JOIN hierarchy h9
-      ON (h9.parentid = co.id AND h9.name='collectionobjects_bampfa:acquisitionDateGroupList' and h9.pos=0)
-   LEFT OUTER JOIN structuredDateGroup sdgac ON (h9.id = sdgac.id)
-   LEFT OUTER JOIN collectionobjects_bampfa_acquisitionsources cas on (co.id=cas.id and cas.pos=0)
-   LEFT OUTER JOIN collectionobjects_common_comments ccom on (co.id=ccom.id and ccom.pos=0)
-   LEFT OUTER JOIN hierarchy h10
-      ON (h10.parentid = co.id AND h10.name = 'collectionobjects_bampfa:catalogerGroupList' and h10.pos=0)
-   LEFT OUTER JOIN catalogergroup cg
-      ON (h10.id = cg.id)
-   LEFT OUTER JOIN hierarchy h11
-      ON (h11.parentid = co.id AND h11.name = 'collectionobjects_bampfa:bampfaObjectProductionPersonGroupList' and h11.pos=0)
-   LEFT OUTER JOIN bampfaobjectproductionpersongroup ba
-      ON (h11.id = ba.id)
-   LEFT OUTER JOIN persons_common pc on (ba.bampfaobjectproductionperson=pc.refname)
-   LEFT OUTER JOIN persons_common_nationalities pcn on (pc.id=pcn.id and pcn.pos=0)
-   LEFT OUTER JOIN hierarchy h12
-      ON (h12.parentid = pc.id AND h12.name='persons_common:birthDateGroup')
-   LEFT OUTER JOIN structuredDateGroup sdgpb ON (h12.id = sdgpb.id)
-   LEFT OUTER JOIN hierarchy h13
-      ON (h13.parentid = pc.id AND h13.name='persons_common:deathDateGroup')
-   LEFT OUTER JOIN structuredDateGroup sdgpd ON (h13.id = sdgpd.id)
-   LEFT OUTER JOIN persons_bampfa pb on (pc.id=pb.id)
-   LEFT OUTER JOIN hierarchy h14
-      ON (h14.parentid = co.id AND h14.name = 'collectionobjects_common:assocPlaceGroupList' and h14.pos=0)
-   LEFT OUTER JOIN assocplacegroup apg
-      ON (h14.id = apg.id)
-   LEFT OUTER JOIN collectionobjects_bampfa_subjectthemes st1 ON (st1.id=co.id and st1.pos=0)
-   LEFT OUTER JOIN collectionobjects_bampfa_subjectthemes st2 ON (st2.id=co.id and st2.pos=1)
-   LEFT OUTER JOIN collectionobjects_bampfa_subjectthemes st3 ON (st3.id=co.id and st3.pos=2)
-   LEFT OUTER JOIN collectionobjects_bampfa_subjectthemes st4 ON (st4.id=co.id and st4.pos=3)
-   LEFT OUTER JOIN collectionobjects_bampfa_subjectthemes st5 ON (st5.id=co.id and st5.pos=4)
+/* metadata_internal.sql
+ *
+ * get metadata for BAMPFA object records
+ *   Subject*: get first five subjects
+ *   grouptitle_ss: aggregate group titles as a semi-colon separated list
+ *   artistCalc: aggregate artists as a semi-colon + space separated list
+ *   artistorigin: calculate artist origin from birthplace and nationality
+ *   initialvalue, currentvalue: redact value data
+ *   fullBAMPFAcreditline: calculated based on collectionobjects_bampfa value
+ *   permissiontoreproduce, copyrightCredit: calculate based on collectionobjects_bampfa, persons_bampfa values
+ *   measurement: replace hyphen with space
+ *   dateacquired: display date from acquisitionDateGroupList, in future will need case to get from intake
+ *   notescomments: replace white space, e.g. CRLF etc with space then trim
+ *   century: calculate from objectProductionDateCentury and objectProductionDateEra
+*/
+
+WITH subjectthemes AS (	-- get first five subjectthemes
+  SELECT
+    id,
+    MAX(CASE WHEN pos = 0 THEN GETDISPL(item) END) AS SubjectOne,
+    MAX(CASE WHEN pos = 1 THEN GETDISPL(item) END) AS SubjectTwo,
+    MAX(CASE WHEN pos = 2 THEN GETDISPL(item) END) AS SubjectThree,
+    MAX(CASE WHEN pos = 3 THEN GETDISPL(item) END) AS SubjectFour,
+    MAX(CASE WHEN pos = 4 THEN GETDISPL(item) END) AS SubjectFive
+  FROM collectionobjects_bampfa_subjectthemes
+  WHERE pos < 5
+  GROUP BY id
+),
+
+groups AS (	-- aggregate group titles for collection objects
+  SELECT
+    rc.objectcsid,
+    STRING_AGG(DISTINCT NULLIF(gc.title, ''), ';' ORDER BY NULLIF(gc.title, '')) AS grouptitle_ss
+  FROM relations_common rc
+    JOIN hierarchy hgc ON rc.subjectcsid = hgc.name
+    LEFT OUTER JOIN groups_common gc ON hgc.id = gc.id
+    JOIN misc mgc ON gc.id = mgc.id
+  WHERE rc.objectdocumenttype = 'CollectionObject'
+    AND rc.subjectdocumenttype = 'Group'
+    AND mgc.lifecyclestate <> 'deleted'	-- exclude deleted groups
+  GROUP BY rc.objectcsid
+)
+
+SELECT
+  hcc.name AS objectCSID,
+  cc.objectnumber AS idNumber,
+  cb.sortableEffectiveObjectNumber AS sortObjectNumber,
+  con.numbervalue AS otherNumber,
+  GETDISPL(cb.itemclass) AS itemclass,
+  COALESCE(NULLIF(cb.artistdisplayoverride, ''), UTILS.CONCAT_ARTISTS(hcc.name)) AS artistCalc,
+  --  GETDISPL(ppg.bampfaobjectproductionperson) AS artist,
+  CASE
+    WHEN NULLIF(pc.birthplace, '') IS NULL THEN pcn.item
+    WHEN pcn.item = pc.birthplace THEN pcn.item
+    ELSE pcn.item || ', born '|| pc.birthplace END AS artistorigin,
+  bdg.datedisplaydate AS artistbirthdate,
+  ddg.datedisplaydate AS artistdeathdate,
+  pb.datesactive,
+  btg.bampfatitle AS title,
+  '-REDACTED-' AS initialvalue,	-- cb.initialvalue,
+  '-REDACTED-' AS currentvalue,	-- cvg.currentvalue,
+  cvg.currentvaluesource,
+  cvdg.datedisplaydate AS currentvaluedate,
+  cb.creditline,
+  'University of California, Berkeley Art Museum and Pacific Film Archive'
+    || COALESCE('; '|| cb.creditline, '') AS fullBAMPFAcreditline,
+  COALESCE(NULLIF(cb.permissiontoreproduce, ''), pb.permissiontoreproduce) AS permissiontoreproduce,
+  COALESCE(NULLIF(cb.copyrightCredit, ''), pb.copyrightCredit) AS copyrightCredit,
+  cb.photoCredit,
+  pdg.datedisplaydate AS dateMade,
+  REPLACE(mpg.dimensionsummary, '-', ' ') AS measurement,
+  cc.physicaldescription AS materials,
+  adg.datedisplaydate AS dateacquired,	-- in future will need case statements to get from intake
+  GETDISPL(cbas.item) AS acquisitionsource,
+  cb.provenance,
+  tig.inscriptioncontent AS signature,
+  TRIM(REGEXP_REPLACE(ccc.item, '[[:space:]]+', ' ', 'g')) AS notescomments,	-- replace CRLF w/space then trim
+  cg.catalogername AS cataloger,
+  cg.catalognote AS catalognote,
+  cg.catalogdate,
+  apg.assocplace AS site,
+  st.SubjectOne,
+  st.SubjectTwo,
+  st.SubjectThree,
+  st.SubjectFour,
+  st.SubjectFive,
+  GETDISPL(cc.computedcurrentlocation) AS currentlocation,
+  GETDISPL(cb.computedcrate) AS currentcrate,
+  TRIM(cb.objectProductionDateCentury) || ' ' || GETDISPL(cb.objectProductionDateEra) AS century,
+  g.grouptitle_ss
+
+FROM collectionobjects_common cc
+  JOIN hierarchy hcc ON cc.id = hcc.id
+  JOIN misc mcc ON cc.id = mcc.id
+  JOIN collectionobjects_bampfa cb ON cc.id = cb.id
+
+  LEFT OUTER JOIN hierarchy hpdg	-- get first production date
+    ON cc.id = hpdg.parentid
+    AND hpdg.name = 'collectionobjects_common:objectProductionDateGroupList'
+    AND hpdg.pos = 0
+  LEFT OUTER JOIN structuredDateGroup pdg ON hpdg.id = pdg.id
+
+  LEFT OUTER JOIN hierarchy hcon	-- get first other number
+    ON cc.id = hcon.parentid
+    AND hcon.name = 'collectionobjects_common:otherNumberList'
+    AND hcon.pos = 0
+  LEFT OUTER JOIN othernumber con ON hcon.id = con.id
+
+  LEFT OUTER JOIN hierarchy hbtg	-- get first title
+    ON cc.id = hbtg.parentid
+    AND hbtg.name = 'collectionobjects_bampfa:bampfaTitleGroupList'
+    AND hbtg.pos = 0
+  LEFT OUTER JOIN bampfatitlegroup btg ON hbtg.id = btg.id
+
+  LEFT OUTER JOIN hierarchy hcvg	-- get first current value
+    ON cc.id = hcvg.parentid
+    AND hcvg.name = 'collectionobjects_bampfa:currentValueGroupList'
+    AND hcvg.pos = 0
+  LEFT OUTER JOIN currentvaluegroup cvg ON hcvg.id = cvg.id
+
+  LEFT OUTER JOIN hierarchy hcvdg	-- get first current value date
+    ON cvg.id = hcvdg.parentid
+    AND hcvdg.name = 'currentValueDateGroup'
+  LEFT OUTER JOIN structuredDateGroup cvdg ON hcvdg.id = cvdg.id
+
+  LEFT OUTER JOIN hierarchy hmpg	-- get first measured part
+    ON cc.id = hmpg.parentid
+    AND hmpg.name = 'collectionobjects_common:measuredPartGroupList'
+    AND hmpg.pos = 0
+  LEFT OUTER JOIN measuredpartgroup mpg ON hmpg.id = mpg.id
+
+  LEFT OUTER JOIN hierarchy htig	-- get first signature
+    ON cc.id = htig.parentid
+    AND htig.name = 'collectionobjects_common:textualInscriptionGroupList'
+    AND htig.pos = 0
+  LEFT OUTER JOIN textualinscriptiongroup tig ON htig.id = tig.id
+
+  LEFT OUTER JOIN hierarchy hadg	-- get first acquisition date
+    ON cc.id = hadg.parentid
+    AND hadg.name = 'collectionobjects_bampfa:acquisitionDateGroupList'
+    AND hadg.pos = 0
+  LEFT OUTER JOIN structuredDateGroup adg ON hadg.id = adg.id
+
+  LEFT OUTER JOIN collectionobjects_bampfa_acquisitionsources cbas	-- get first acquisition source
+    ON cc.id = cbas.id
+    AND cbas.pos = 0
+
+  LEFT OUTER JOIN collectionobjects_common_comments ccc	-- get first collection object comment
+    ON cc.id = ccc.id
+    AND ccc.pos = 0
+
+  LEFT OUTER JOIN hierarchy hcg	-- get first cataloger
+    ON cc.id = hcg.parentid
+    AND hcg.name = 'collectionobjects_bampfa:catalogerGroupList'
+    AND hcg.pos = 0
+  LEFT OUTER JOIN catalogergroup cg ON hcg.id = cg.id
+
+  LEFT OUTER JOIN hierarchy hppg	-- get first artist
+    ON cc.id = hppg.parentid
+    AND hppg.name = 'collectionobjects_bampfa:bampfaObjectProductionPersonGroupList'
+    AND hppg.pos = 0
+  LEFT OUTER JOIN bampfaobjectproductionpersongroup ppg ON hppg.id = ppg.id
+  LEFT OUTER JOIN persons_common pc ON ppg.bampfaobjectproductionperson = pc.refname
+
+  LEFT OUTER JOIN persons_common_nationalities pcn	-- get first nationality of first artist
+    ON pc.id = pcn.id
+    AND pcn.pos = 0
+
+  LEFT OUTER JOIN persons_bampfa pb ON pc.id = pb.id	-- get active dates, permissions, copyright for first artist
+
+  LEFT OUTER JOIN hierarchy hbdg	-- get birth date of first artist
+    ON pc.id = hbdg.parentid
+    AND hbdg.name = 'persons_common:birthDateGroup'
+  LEFT OUTER JOIN structuredDateGroup bdg ON hbdg.id = bdg.id
+
+  LEFT OUTER JOIN hierarchy hddg	-- get death date of first artist
+    ON pc.id = hddg.parentid
+    AND hddg.name = 'persons_common:deathDateGroup'
+  LEFT OUTER JOIN structuredDateGroup ddg ON hddg.id = ddg.id
+
+  LEFT OUTER JOIN hierarchy hapg	-- get first collection site of collection object
+    ON cc.id = hapg.parentid
+    AND hapg.name = 'collectionobjects_common:assocPlaceGroupList'
+    AND hapg.pos = 0
+  LEFT OUTER JOIN assocplacegroup apg ON hapg.id = apg.id
+
+  LEFT OUTER JOIN subjectthemes st ON cc.id = st.id	-- get subjects
+
+  LEFT OUTER JOIN groups g ON hcc.name = g.objectcsid	-- get group titles
+
+WHERE mcc.lifecyclestate <> 'deleted'	-- exclude deleted objects
+

--- a/bampfa/metadata_public.sql
+++ b/bampfa/metadata_public.sql
@@ -1,166 +1,180 @@
-with subjecttheme_rank as (
-  select 
-    id,
-    getdispl(item) as item,
-    row_number() over(partition by id order by pos) as pos_index
-  from collectionobjects_bampfa_subjectthemes
-),
+/* metadata_public.sql
+ *
+ * get metadata for BAMPFA object records
+ *   Subject*: get first five subjects
+ *   grouptitle_ss: set to 'not yet available'
+ *   artistCalc: aggregate artists as a semi-colon + space separated list
+ *   artistorigin: calculate artist origin from birthplace and nationality
+ *   initialvalue, currentvalue: redact value data
+ *   fullBAMPFAcreditline: calculated based on collectionobjects_bampfa value
+ *   permissiontoreproduce, copyrightCredit: calculate based on collectionobjects_bampfa, persons_bampfa values
+ *   measurement: replace hyphen with space
+ *   dateacquired: display date from acquisitionDateGroupList, in future will need case to get from intake
+ *   notescomments: replace white space, e.g. CRLF etc with space then trim
+ *   century: calculate from objectProductionDateCentury and objectProductionDateEra
+ *   dateMadeYear_dt: formatted as 'YYYY-MM-Dd from datelatestscalarvalue of first production date
+*/
 
-subjectthemes as (
-  select 
+WITH subjectthemes AS (	-- get first five subjectthemes
+  SELECT
     id,
-    max(case when pos_index = 1 THEN item end) AS SubjectOne,
-    max(case when pos_index = 2 THEN item end) AS SubjectTwo,
-    max(case when pos_index = 3 THEN item end) AS SubjectThree,
-    max(case when pos_index = 4 THEN item end) AS SubjectFour,
-    max(case when pos_index = 5 THEN item end) AS SubjectFive
-  from subjecttheme_rank
-  where pos_index <= 5
-  group by id
+    MAX(CASE WHEN pos = 0 THEN GETDISPL(item) END) AS SubjectOne,
+    MAX(CASE WHEN pos = 1 THEN GETDISPL(item) END) AS SubjectTwo,
+    MAX(CASE WHEN pos = 2 THEN GETDISPL(item) END) AS SubjectThree,
+    MAX(CASE WHEN pos = 3 THEN GETDISPL(item) END) AS SubjectFour,
+    MAX(CASE WHEN pos = 4 THEN GETDISPL(item) END) AS SubjectFive
+  FROM collectionobjects_bampfa_subjectthemes
+  WHERE pos < 5
+  GROUP BY id
 )
 
-select
-   hcc.name as objectCSID,
-   cc.objectnumber as idNumber,
-   cb.sortableEffectiveObjectNumber as sortObjectNumber,
-   con.numbervalue as otherNumber,
-   getdispl(cb.itemclass) as itemclass,
-   coalesce(nullif(cb.artistdisplayoverride, ''), utils.concat_artists(hcc.name)) as artistCalc,
-   --   getdispl(opp.bampfaobjectproductionperson) as artist,
-   case
-     when nullif(pc.birthplace, '') is null then pcn.item
-     when pcn.item = pc.birthplace then pcn.item
-     else pcn.item || ', born '|| pc.birthplace end as artistorigin,
-   bdg.datedisplaydate as artistbirthdate,
-   ddg.datedisplaydate as artistdeathdate,
-   pb.datesactive,
-   bt.bampfatitle as title,
-   '-REDACTED-' as initialvalue,  -- cb.initialvalue,
-   '-REDACTED-' as currentvalue,  -- cv.currentvalue,
-   cvg.currentvaluesource,
-   cvdg.datedisplaydate as currentvaluedate,
-   cb.creditline,
-   'University of California, Berkeley Art Museum and Pacific Film Archive' || coalesce('; '|| cb.creditline, '') as fullBAMPFAcreditline,
-   coalesce(nullif(cb.permissiontoreproduce, ''), pb.permissiontoreproduce) as permissiontoreproduce,
-   coalesce(nullif(cb.copyrightCredit, ''), pb.copyrightCredit) as copyrightCredit,
-   cb.photoCredit,
-   sdg.datedisplaydate as dateMade,
-   replace(mpg.dimensionsummary, '-', ' ') as measurement,
-   cc.physicaldescription as materials,
-   adg.datedisplaydate as dateacquired, -- in future will need case statements to get from intake
-   getdispl(cbas.item) as acquisitionsource,
-   cb.provenance,
-   tig.inscriptioncontent as signature,
-   ccc.item as notescomments,
-   cg.catalogername as cataloger,
-   cg.catalognote as catalognote,
-   cg.catalogdate,
-   apg.assocplace as site,
-   st.SubjectOne,
-   st.SubjectTwo,
-   st.SubjectThree,
-   st.SubjectFour,
-   st.SubjectFive,
-   -- these values are included here, but eliminated during the loading process
-   getdispl(cc.computedcurrentlocation) as currentlocation,
-   getdispl(cb.computedcrate) as currentcrate,
-   trim(cb.objectProductionDateCentury) || ' ' || getdispl(cb.objectProductionDateEra) as century,
-   'not yet available' as grouptitle_ss,
-   to_char(sdg.datelatestscalarvalue, 'YYYY-MM-DD') as dateMadeYear_dt
-from
-   hierarchy hcc
-   JOIN collectionobjects_common cc on (hcc.id = cc.id)
-   JOIN misc m on (cc.id = m.id and m.lifecyclestate <> 'deleted')
-   JOIN collectionobjects_bampfa cb on (cc.id = cb.id)
+SELECT
+  hcc.name AS objectCSID,
+  cc.objectnumber AS idNumber,
+  cb.sortableEffectiveObjectNumber AS sortObjectNumber,
+  con.numbervalue AS otherNumber,
+  GETDISPL(cb.itemclass) AS itemclass,
+  COALESCE(NULLIF(cb.artistdisplayoverride, ''), UTILS.CONCAT_ARTISTS(hcc.name)) AS artistCalc,
+  --  GETDISPL(ppg.bampfaobjectproductionperson) AS artist,
+  CASE
+    WHEN NULLIF(pc.birthplace, '') IS NULL THEN pcn.item
+    WHEN pcn.item = pc.birthplace THEN pcn.item
+    ELSE pcn.item || ', born '|| pc.birthplace END AS artistorigin,
+  bdg.datedisplaydate AS artistbirthdate,
+  ddg.datedisplaydate AS artistdeathdate,
+  pb.datesactive,
+  btg.bampfatitle AS title,
+  '-REDACTED-' AS initialvalue,	-- cb.initialvalue,
+  '-REDACTED-' AS currentvalue,	-- cvg.currentvalue,
+  cvg.currentvaluesource,
+  cvdg.datedisplaydate AS currentvaluedate,
+  cb.creditline,
+  'University of California, Berkeley Art Museum and Pacific Film Archive'
+    || COALESCE('; '|| cb.creditline, '') AS fullBAMPFAcreditline,
+  COALESCE(NULLIF(cb.permissiontoreproduce, ''), pb.permissiontoreproduce) AS permissiontoreproduce,
+  COALESCE(NULLIF(cb.copyrightCredit, ''), pb.copyrightCredit) AS copyrightCredit,
+  cb.photoCredit,
+  pdg.datedisplaydate AS dateMade,
+  REPLACE(mpg.dimensionsummary, '-', ' ') AS measurement,
+  cc.physicaldescription AS materials,
+  adg.datedisplaydate AS dateacquired,	-- in future will need case statements to get from intake
+  GETDISPL(cbas.item) AS acquisitionsource,
+  cb.provenance,
+  tig.inscriptioncontent AS signature,
+  TRIM(REGEXP_REPLACE(ccc.item, '[[:space:]]+', ' ', 'g')) AS notescomments,	-- replace CRLF w/space then trim
+  cg.catalogername AS cataloger,
+  cg.catalognote AS catalognote,
+  cg.catalogdate,
+  apg.assocplace AS site,
+  st.SubjectOne,
+  st.SubjectTwo,
+  st.SubjectThree,
+  st.SubjectFour,
+  st.SubjectFive,
+  -- these values are included here, but eliminated during the loading process
+  GETDISPL(cc.computedcurrentlocation) AS currentlocation,
+  GETDISPL(cb.computedcrate) AS currentcrate,
+  TRIM(cb.objectProductionDateCentury) || ' ' || GETDISPL(cb.objectProductionDateEra) AS century,
+  'not yet available' AS grouptitle_ss,
+  TO_CHAR(pdg.datelatestscalarvalue, 'YYYY-MM-DD') AS dateMadeYear_dt
 
-   left outer join hierarchy h2 on (
-      h2.parentid = cc.id 
-      and h2.name = 'collectionobjects_common:objectProductionDateGroupList'
-      and h2.pos = 0)
-   left outer join structuredDateGroup sdg on (h2.id = sdg.id)
+FROM collectionobjects_common cc
+  JOIN hierarchy hcc ON cc.id = hcc.id
+  JOIN misc mcc ON cc.id = mcc.id
+  JOIN collectionobjects_bampfa cb ON cc.id = cb.id
 
-   left outer join hierarchy hcon on (
-      hcon.parentid = cc.id
-      and hcon.name = 'collectionobjects_common:otherNumberList'
-      and hcon.pos = 0)
-   left outer join othernumber con on (hcon.id = con.id)
+  LEFT OUTER JOIN hierarchy hpdg	-- get first production date
+    ON cc.id = hpdg.parentid
+    AND hpdg.name = 'collectionobjects_common:objectProductionDateGroupList'
+    AND hpdg.pos = 0
+  LEFT OUTER JOIN structuredDateGroup pdg ON hpdg.id = pdg.id
 
-   left outer join hierarchy hbt on (
-      hbt.parentid = cc.id
-      and hbt.name = 'collectionobjects_bampfa:bampfaTitleGroupList'
-      and hbt.pos = 0)
-   left outer join bampfatitlegroup bt on (hbt.id = bt.id)
+  LEFT OUTER JOIN hierarchy hcon	-- get first other number
+    ON cc.id = hcon.parentid
+    AND hcon.name = 'collectionobjects_common:otherNumberList'
+    AND hcon.pos = 0
+  LEFT OUTER JOIN othernumber con ON hcon.id = con.id
 
-   left outer join hierarchy hcvg
-      on (hcvg.parentid = cc.id
-      and hcvg.name = 'collectionobjects_bampfa:currentValueGroupList'
-      and hcvg.pos = 0)
-   left outer join currentvaluegroup cvg on (hcvg.id = cvg.id)
+  LEFT OUTER JOIN hierarchy hbtg	-- get first title
+    ON cc.id = hbtg.parentid
+    AND hbtg.name = 'collectionobjects_bampfa:bampfaTitleGroupList'
+    AND hbtg.pos = 0
+  LEFT OUTER JOIN bampfatitlegroup btg ON hbtg.id = btg.id
 
-   left outer join hierarchy hcvdg
-      on (hcvdg.parentid = cvg.id
-      and hcvdg.name = 'currentValueDateGroup')
-   left outer join structuredDateGroup cvdg on (hcvdg.id = cvdg.id)
+  LEFT OUTER JOIN hierarchy hcvg	-- get first current value
+    ON cc.id = hcvg.parentid
+    AND hcvg.name = 'collectionobjects_bampfa:currentValueGroupList'
+    AND hcvg.pos = 0
+  LEFT OUTER JOIN currentvaluegroup cvg ON hcvg.id = cvg.id
 
-   left outer join hierarchy hmpg
-      on (hmpg.parentid = cc.id
-      and hmpg.name = 'collectionobjects_common:measuredPartGroupList'
-      and hmpg.pos = 0)
-   left outer join measuredpartgroup mpg on (hmpg.id = mpg.id)
+  LEFT OUTER JOIN hierarchy hcvdg	-- get first current value date
+    ON cvg.id = hcvdg.parentid
+    AND hcvdg.name = 'currentValueDateGroup'
+  LEFT OUTER JOIN structuredDateGroup cvdg ON hcvdg.id = cvdg.id
 
-   left outer join hierarchy htig
-      on (htig.parentid = cc.id
-      and htig.name = 'collectionobjects_common:textualInscriptionGroupList'
-      and htig.pos = 0)
-   left outer join textualinscriptiongroup tig on (htig.id = tig.id)
+  LEFT OUTER JOIN hierarchy hmpg	-- get first measured part
+    ON cc.id = hmpg.parentid
+    AND hmpg.name = 'collectionobjects_common:measuredPartGroupList'
+    AND hmpg.pos = 0
+  LEFT OUTER JOIN measuredpartgroup mpg ON hmpg.id = mpg.id
 
-   left outer join hierarchy hadg
-      on (hadg.parentid = cc.id
-      and hadg.name = 'collectionobjects_bampfa:acquisitionDateGroupList'
-      and hadg.pos = 0)
-   left outer join structuredDateGroup adg on (hadg.id = adg.id)
+  LEFT OUTER JOIN hierarchy htig	-- get first signature
+    ON cc.id = htig.parentid
+    AND htig.name = 'collectionobjects_common:textualInscriptionGroupList'
+    AND htig.pos = 0
+  LEFT OUTER JOIN textualinscriptiongroup tig ON htig.id = tig.id
 
-   left outer join collectionobjects_bampfa_acquisitionsources cbas on (
-      cc.id = cbas.id
-      and cbas.pos = 0)
+  LEFT OUTER JOIN hierarchy hadg	-- get first acquisition date
+    ON cc.id = hadg.parentid
+    AND hadg.name = 'collectionobjects_bampfa:acquisitionDateGroupList'
+    AND hadg.pos = 0
+  LEFT OUTER JOIN structuredDateGroup adg ON hadg.id = adg.id
 
-   left outer join collectionobjects_common_comments ccc on (
-      cc.id = ccc.id
-      and ccc.pos = 0)
+  LEFT OUTER JOIN collectionobjects_bampfa_acquisitionsources cbas	-- get first acquisition source
+    ON cc.id = cbas.id
+    AND cbas.pos = 0
 
-   left outer join hierarchy hcg
-      on (hcg.parentid = cc.id
-      and hcg.name = 'collectionobjects_bampfa:catalogerGroupList'
-      and hcg.pos = 0)
-   left outer join catalogergroup cg on (hcg.id = cg.id)
+  LEFT OUTER JOIN collectionobjects_common_comments ccc	-- get first collection object comment
+    ON cc.id = ccc.id
+    AND ccc.pos = 0
 
-   left outer join hierarchy hopp
-      on (hopp.parentid = cc.id
-      and hopp.name = 'collectionobjects_bampfa:bampfaObjectProductionPersonGroupList'
-      and hopp.pos = 0)
-   left outer join bampfaobjectproductionpersongroup opp on (hopp.id = opp.id)
-   left outer join persons_common pc on (opp.bampfaobjectproductionperson = pc.refname)
-   left outer join persons_common_nationalities pcn on (
-      pc.id = pcn.id
-      and pcn.pos = 0)
-   left outer join persons_bampfa pb on (pc.id = pb.id)
+  LEFT OUTER JOIN hierarchy hcg	-- get first cataloger
+    ON cc.id = hcg.parentid
+    AND hcg.name = 'collectionobjects_bampfa:catalogerGroupList'
+    AND hcg.pos = 0
+  LEFT OUTER JOIN catalogergroup cg ON hcg.id = cg.id
 
-   left outer join hierarchy hbdg
-      on (hbdg.parentid = pc.id
-      and hbdg.name = 'persons_common:birthDateGroup')
-   left outer join structuredDateGroup bdg on (hbdg.id = bdg.id)
+  LEFT OUTER JOIN hierarchy hppg	-- get first artist
+    ON cc.id = hppg.parentid
+    AND hppg.name = 'collectionobjects_bampfa:bampfaObjectProductionPersonGroupList'
+    AND hppg.pos = 0
+  LEFT OUTER JOIN bampfaobjectproductionpersongroup ppg ON hppg.id = ppg.id
+  LEFT OUTER JOIN persons_common pc ON ppg.bampfaobjectproductionperson = pc.refname
 
-   left outer join hierarchy hddg
-      on (hddg.parentid = pc.id
-      and hddg.name = 'persons_common:deathDateGroup')
-   left outer join structuredDateGroup ddg on (hddg.id = ddg.id)
+  LEFT OUTER JOIN persons_common_nationalities pcn	-- get first nationality of first artist
+    ON pc.id = pcn.id
+    AND pcn.pos = 0
 
-   left outer join hierarchy hapg
-      on (hapg.parentid = cc.id
-      and hapg.name = 'collectionobjects_common:assocPlaceGroupList'
-      and hapg.pos = 0)
-   left outer join assocplacegroup apg on (hapg.id = apg.id)
+  LEFT OUTER JOIN persons_bampfa pb ON pc.id = pb.id	-- get active dates, permissions, copyright for first artist
 
-   left outer join subjectthemes st on (cc.id = st.id)
+  LEFT OUTER JOIN hierarchy hbdg	-- get birth date of first artist
+    ON pc.id = hbdg.parentid
+    AND hbdg.name = 'persons_common:birthDateGroup'
+  LEFT OUTER JOIN structuredDateGroup bdg ON hbdg.id = bdg.id
 
-where getdispl(cb.legalstatus) in ('permanent collection', 'extended loan', 'UCBerkeley dispersed')
+  LEFT OUTER JOIN hierarchy hddg	-- get death date of first artist
+    ON pc.id = hddg.parentid
+    AND hddg.name = 'persons_common:deathDateGroup'
+  LEFT OUTER JOIN structuredDateGroup ddg ON hddg.id = ddg.id
+
+  LEFT OUTER JOIN hierarchy hapg	-- get first collection site of collection object
+    ON cc.id = hapg.parentid
+    AND hapg.name = 'collectionobjects_common:assocPlaceGroupList'
+    AND hapg.pos = 0
+  LEFT OUTER JOIN assocplacegroup apg ON hapg.id = apg.id
+
+  LEFT OUTER JOIN subjectthemes st ON cc.id = st.id	-- get subjects
+
+WHERE mcc.lifecyclestate <> 'deleted'	-- exclude deleted objects
+  AND GETDISPL(cb.legalstatus) IN ('permanent collection', 'extended loan', 'UCBerkeley dispersed')
+


### PR DESCRIPTION
bampfa_collectionitems_vw.sql
- update query to match metadata_public.sql
- remove extraneous join to collectionspace_core
- NOTE: site data source is different from Solr metadata queries, ie objectproductionplace vs assocplace

media_internal.sql, media_public.sql
- exclude deleted relations,  collection objects, and blobs (as well as media)

metadata_internal.sql, metadata_public.sql
- remove extraneous subjectthemes_rank CTE


