### PR TITLE
CSW-1012: uncompress county/state/country files for public Solr extract

### DIFF
--- a/botgarden/solrETL-public.sh
+++ b/botgarden/solrETL-public.sh
@@ -42,10 +42,11 @@ wait
 ##############################################################################
 # temporary hack to parse Locality into County/State/Country
 ##############################################################################
-# 1. recover yesterday's version of these 3 files
-cp ${SOLR_CACHE_DIR}/county.csv .
-cp ${SOLR_CACHE_DIR}/state.csv .
-cp ${SOLR_CACHE_DIR}/country.csv .
+# 1. recover latest version of these 3 files, which were zipped via the previous run of one_job.sh
+gunzip -c ${SOLR_CACHE_DIR}/county.csv.gz > county.csv
+gunzip -c ${SOLR_CACHE_DIR}/state.csv.gz > state.csv
+gunzip -c ${SOLR_CACHE_DIR}/country.csv.gz > country.csv
+
 # parse the extracted field, insert into metadata
 perl fixLocalites.pl d5.csv > metadata.csv
 # 3. we need to regenerate and save these 3 files for the next run...


### PR DESCRIPTION
[solrETL-public.sh](https://github.com/cspace-deployment/cspace-solr-ucb/blob/81e454ebd526b3836bea48f6e3c02c27c27922fa/botgarden/solrETL-public.sh#L45-L48) has been failing to copy county, state, and country csv files.  This means the county/state/country lookup was being rebuilt nightly.
